### PR TITLE
✨ Add block management

### DIFF
--- a/src/api/routes/block.py
+++ b/src/api/routes/block.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session as DBSession
+
+from src.api.deps import get_db
+from src.api.schemas.block import (
+    BlockCreate,
+    BlockRead,
+    BlockUpdate,
+)
+from src.services.block_service import BlockService
+
+router = APIRouter(prefix="/blocks", tags=["blocks"])
+
+
+@router.post("/", response_model=BlockRead)
+def create_block(
+    payload: BlockCreate,
+    db: DBSession = Depends(get_db),
+):
+    try:
+        return BlockService(db).create_block(**payload.model_dump())
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.get("/{block_id}", response_model=BlockRead)
+def get_block(block_id: int, db: DBSession = Depends(get_db)):
+    block = BlockService(db).get_block(block_id)
+    if not block:
+        raise HTTPException(status_code=404, detail="Block not found")
+    return block
+
+
+@router.get("/session/{session_id}", response_model=list[BlockRead])
+def list_blocks_by_session(
+    session_id: int,
+    db: DBSession = Depends(get_db),
+):
+    return BlockService(db).list_blocks_by_session(session_id)
+
+
+@router.patch("/{block_id}", response_model=BlockRead)
+def update_block(
+    block_id: int,
+    payload: BlockUpdate,
+    db: DBSession = Depends(get_db),
+):
+    try:
+        return BlockService(db).update_block(
+            block_id,
+            **payload.model_dump(exclude_unset=True),
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+
+@router.delete("/{block_id}", status_code=204)
+def delete_block(block_id: int, db: DBSession = Depends(get_db)):
+    try:
+        BlockService(db).delete_block(block_id)
+    except ValueError as e:
+        raise HTTPException(status_code=404, detail=str(e))

--- a/src/api/schemas/block.py
+++ b/src/api/schemas/block.py
@@ -1,0 +1,60 @@
+from pydantic import BaseModel, Field
+from src.data.models import BlockType
+
+
+class BlockCreate(BaseModel):
+    block_type: BlockType = Field(..., description="Type of the block")
+    position: int = Field(..., description="Position of the block within the session")
+    session_id: int = Field(..., description="ID of the session this block belongs to")
+    duration: float | None = Field(
+        None,
+        description="Optional duration of the block in minutes",
+    )
+    notes: str | None = Field(
+        None,
+        description="Optional notes for the block",
+    )
+
+    model_config = {
+        "populate_by_name": True,
+        "extra": "forbid",
+    }
+
+
+class BlockUpdate(BaseModel):
+    block_type: BlockType | None = Field(
+        None,
+        description="Updated type of the block",
+    )
+    position: int | None = Field(
+        None,
+        description="Updated position of the block within the session",
+    )
+    duration: float | None = Field(
+        None,
+        description="Updated duration of the block in minutes",
+    )
+    notes: str | None = Field(
+        None,
+        description="Updated notes for the block",
+    )
+
+    model_config = {
+        "populate_by_name": True,
+        "extra": "forbid",
+    }
+
+
+class BlockRead(BaseModel):
+    id: int
+    block_type: BlockType
+    position: int
+    session_id: int
+    duration: float | None
+    notes: str | None
+
+    model_config = {
+        "populate_by_name": True,
+        "from_attributes": True,
+        "extra": "forbid",
+    }

--- a/src/data/dao/block_dao.py
+++ b/src/data/dao/block_dao.py
@@ -1,0 +1,31 @@
+from sqlalchemy.orm import Session as DBSession
+from sqlalchemy import select
+
+from src.data.models import Block
+
+
+class BlockDAO:
+    def __init__(self, db: DBSession):
+        self.db = db
+
+    def create(self, block: Block) -> Block:
+        self.db.add(block)
+        self.db.commit()
+        self.db.refresh(block)
+        return block
+
+    def get_by_id(self, block_id: int) -> Block | None:
+        return self.db.get(Block, block_id)
+
+    def list_by_session(self, session_id: int) -> list[Block]:
+        stmt = select(Block).where(Block.session_id == session_id)
+        return list(self.db.scalars(stmt))
+
+    def update(self, block: Block) -> Block:
+        self.db.commit()
+        self.db.refresh(block)
+        return block
+
+    def delete(self, block: Block) -> None:
+        self.db.delete(block)
+        self.db.commit()

--- a/src/main.py
+++ b/src/main.py
@@ -2,9 +2,11 @@ from fastapi import FastAPI
 from src.api.routes.user import router as users_router
 from src.api.routes.session import router as session_router
 from src.api.routes.location import router as location_router
+from src.api.routes.block import router as block_router
 
 app = FastAPI()
 
 app.include_router(users_router)
 app.include_router(session_router)
 app.include_router(location_router)
+app.include_router(block_router)

--- a/src/services/block_service.py
+++ b/src/services/block_service.py
@@ -1,0 +1,70 @@
+from sqlalchemy.orm import Session as DBSession
+
+from src.data.dao.block_dao import BlockDAO
+from src.data.models import Block, BlockType
+from src.services.session_service import SessionService
+
+
+class BlockService:
+    def __init__(self, db: DBSession):
+        self.block_dao = BlockDAO(db)
+        self.session_service = SessionService(db)
+
+    def create_block(
+        self,
+        *,
+        block_type: BlockType,
+        position: int,
+        session_id: int,
+        duration: float | None = None,
+        notes: str | None = None,
+    ) -> Block:
+        session = self.session_service.get_session(session_id)
+        if not session:
+            raise ValueError("Session not found")
+
+        block = Block(
+            block_type=block_type,
+            position=position,
+            session_id=session_id,
+            duration=duration,
+            notes=notes,
+        )
+        return self.block_dao.create(block)
+
+    def get_block(self, block_id: int) -> Block | None:
+        return self.block_dao.get_by_id(block_id)
+
+    def list_blocks_by_session(self, session_id: int) -> list[Block]:
+        return self.block_dao.list_by_session(session_id)
+
+    def update_block(
+        self,
+        block_id: int,
+        *,
+        block_type: BlockType | None = None,
+        position: int | None = None,
+        duration: float | None = None,
+        notes: str | None = None,
+    ) -> Block:
+        block = self.block_dao.get_by_id(block_id)
+        if not block:
+            raise ValueError("Block not found")
+
+        if block_type is not None:
+            block.block_type = block_type
+        if position is not None:
+            block.position = position
+        if duration is not None:
+            block.duration = duration
+        if notes is not None:
+            block.notes = notes
+
+        return self.block_dao.update(block)
+
+    def delete_block(self, block_id: int) -> None:
+        block = self.block_dao.get_by_id(block_id)
+        if not block:
+            raise ValueError("Block not found")
+
+        self.block_dao.delete(block)

--- a/tests/api/test_block_route.py
+++ b/tests/api/test_block_route.py
@@ -1,0 +1,150 @@
+def test_create_block(client):
+    client_app, mocks = client
+
+    payload = {
+        "block_type": "AMRAP",
+        "position": 1,
+        "session_id": 1,
+        "duration": 15.0,
+        "notes": "Warm-up"
+    }
+
+    mocks["block"].create_block.return_value = {
+        "id": 1,
+        "block_type": "AMRAP",
+        "position": 1,
+        "session_id": 1,
+        "duration": 15.0,
+        "notes": "Warm-up"
+    }
+
+    response = client_app.post("/blocks/", json=payload)
+
+    assert response.status_code == 200
+    assert response.json() == mocks["block"].create_block.return_value
+
+
+def test_create_block_session_not_found(client):
+    client_app, mocks = client
+    mocks["block"].create_block.side_effect = ValueError("Session not found")
+
+    payload = {
+        "block_type": "EMOM",
+        "position": 1,
+        "session_id": 99
+    }
+
+    response = client_app.post("/blocks/", json=payload)
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Session not found"
+
+
+def test_get_block_found(client):
+    client_app, mocks = client
+    mock_block = {
+        "id": 1,
+        "block_type": "AMRAP",
+        "position": 1,
+        "session_id": 1,
+        "duration": 12.0,
+        "notes": None
+    }
+    mocks["block"].get_block.return_value = mock_block
+
+    response = client_app.get("/blocks/1")
+
+    assert response.status_code == 200
+    assert response.json() == mock_block
+
+
+def test_get_block_not_found(client):
+    client_app, mocks = client
+    mocks["block"].get_block.return_value = None
+
+    response = client_app.get("/blocks/999")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Block not found"
+
+
+def test_list_blocks_by_session(client):
+    client_app, mocks = client
+    mock_blocks = [
+        {
+            "id": 1,
+            "block_type": "AMRAP",
+            "position": 1,
+            "session_id": 1,
+            "duration": 10.0,
+            "notes": None
+        },
+        {
+            "id": 2,
+            "block_type": "EMOM",
+            "position": 2,
+            "session_id": 1,
+            "duration": 12.0,
+            "notes": "Heavy"
+        }
+    ]
+    mocks["block"].list_blocks_by_session.return_value = mock_blocks
+
+    response = client_app.get("/blocks/session/1")
+
+    assert response.status_code == 200
+    assert response.json() == mock_blocks
+
+
+def test_update_block_success(client):
+    client_app, mocks = client
+
+    payload = {
+        "position": 2,
+        "notes": "Updated notes"
+    }
+
+    mock_updated = {
+        "id": 1,
+        "block_type": "AMRAP",
+        "position": 2,
+        "session_id": 1,
+        "duration": 15.0,
+        "notes": "Updated notes"
+    }
+
+    mocks["block"].update_block.return_value = mock_updated
+
+    response = client_app.patch("/blocks/1", json=payload)
+
+    assert response.status_code == 200
+    assert response.json() == mock_updated
+
+
+def test_update_block_not_found(client):
+    client_app, mocks = client
+    mocks["block"].update_block.side_effect = ValueError("Block not found")
+
+    response = client_app.patch("/blocks/999", json={"position": 1})
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Block not found"
+
+
+def test_delete_block_success(client):
+    client_app, mocks = client
+
+    response = client_app.delete("/blocks/1")
+
+    assert response.status_code == 204
+    mocks["block"].delete_block.assert_called_once_with(1)
+
+
+def test_delete_block_not_found(client):
+    client_app, mocks = client
+    mocks["block"].delete_block.side_effect = ValueError("Block not found")
+
+    response = client_app.delete("/blocks/999")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Block not found"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,11 @@ from unittest.mock import MagicMock
 from src.services.user_service import UserService
 from src.services.session_service import SessionService
 from src.services.location_service import LocationService
+from src.services.block_service import BlockService
 from src.data.dao.session_dao import SessionDAO
 from src.data.dao.user_dao import UserDAO
 from src.data.dao.location_dao import LocationDAO
+from src.data.dao.block_dao import BlockDAO
 
 @pytest.fixture
 def client(monkeypatch):
@@ -42,6 +44,14 @@ def client(monkeypatch):
         lambda db=None: location_mock
     )
     mock_service_instances['location'] = location_mock
+
+    # Mock BlockService
+    block_mock = MagicMock()
+    monkeypatch.setattr(
+        "src.api.routes.block.BlockService",
+        lambda db=None: block_mock
+    )
+    mock_service_instances['block'] = block_mock
 
     return TestClient(app), mock_service_instances
 
@@ -82,6 +92,21 @@ def mock_services_dao(monkeypatch):
     )
     mocks['location'] = location_mock
 
+    # BlockService
+    block_mock = MagicMock()
+    monkeypatch.setattr(
+        "src.services.block_service.BlockDAO",
+        lambda db=None: block_mock
+    )
+    mocks['block'] = block_mock
+
+    block_session_mock = MagicMock()
+    monkeypatch.setattr(
+        "src.services.block_service.SessionService",
+        lambda db=None: block_session_mock
+    )
+    mocks['block_session'] = block_session_mock
+
     return mocks
 
 
@@ -103,6 +128,11 @@ def location_service(mock_services_dao):
     return LocationService(db=mock_services_dao['location'])
 
 @pytest.fixture
+def block_service(mock_services_dao):
+    """BlockService avec DAO mocké."""
+    return BlockService(db=mock_services_dao['block'])
+
+@pytest.fixture
 def mock_dbs():
     """
     Retourne un dictionnaire de MagicMocks représentant les sessions DB, users DB et locations DB.
@@ -111,6 +141,7 @@ def mock_dbs():
         "session": MagicMock(),
         "user": MagicMock(),
         "location": MagicMock(),
+        "block": MagicMock(),
     }
 
 @pytest.fixture
@@ -127,3 +158,8 @@ def user_dao(mock_dbs):
 def location_dao(mock_dbs):
     """LocationDAO avec DB mockée."""
     return LocationDAO(mock_dbs["location"])
+
+@pytest.fixture
+def block_dao(mock_dbs):
+    """BlockDAO avec DB mockée."""
+    return BlockDAO(mock_dbs["block"])

--- a/tests/data/dao/test_block_dao.py
+++ b/tests/data/dao/test_block_dao.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock
+from src.data.models import Block, BlockType
+
+
+def test_create(block_dao, mock_dbs):
+    mock_db = mock_dbs["block"]
+
+    block = Block(
+        block_type=BlockType.amrap,
+        position=1,
+        session_id=1,
+        duration=12,
+        notes="Warm up",
+    )
+
+    result = block_dao.create(block)
+
+    mock_db.add.assert_called_once_with(block)
+    mock_db.commit.assert_called_once()
+    mock_db.refresh.assert_called_once_with(block)
+    assert result == block
+
+
+def test_get_by_id(block_dao, mock_dbs):
+    mock_db = mock_dbs["block"]
+    mock_db.get.return_value = "found"
+
+    result = block_dao.get_by_id(1)
+
+    mock_db.get.assert_called_once_with(Block, 1)
+    assert result == "found"
+
+
+def test_list_by_session(block_dao, mock_dbs):
+    mock_db = mock_dbs["block"]
+    mock_db.scalars.return_value = ["b1", "b2"]
+
+    result = block_dao.list_by_session(session_id=1)
+
+    mock_db.scalars.assert_called_once()
+    assert result == ["b1", "b2"]
+
+
+def test_update(block_dao, mock_dbs):
+    mock_db = mock_dbs["block"]
+    block = MagicMock()
+
+    result = block_dao.update(block)
+
+    mock_db.commit.assert_called_once()
+    mock_db.refresh.assert_called_once_with(block)
+    assert result == block
+
+
+def test_delete(block_dao, mock_dbs):
+    mock_db = mock_dbs["block"]
+    block = MagicMock()
+
+    block_dao.delete(block)
+
+    mock_db.delete.assert_called_once_with(block)
+    mock_db.commit.assert_called_once()

--- a/tests/sevices/test_block_service.py
+++ b/tests/sevices/test_block_service.py
@@ -1,0 +1,114 @@
+import pytest
+from unittest.mock import MagicMock
+from src.data.models import Block, BlockType
+
+
+def test_create_block(block_service, mock_services_dao):
+    mock_dao = mock_services_dao["block"]
+    session_service = mock_services_dao["block_session"]
+
+    mock_block = Block(
+        block_type=BlockType.amrap,
+        position=1,
+        session_id=1,
+        duration=12,
+        notes="Warm up",
+    )
+
+    mock_dao.create.return_value = mock_block
+    session_service.get_session.return_value = MagicMock(id=1)
+
+    result = block_service.create_block(
+        block_type=BlockType.amrap,
+        position=1,
+        session_id=1,
+        duration=12,
+        notes="Warm up",
+    )
+
+    session_service.get_session.assert_called_once_with(1)
+    mock_dao.create.assert_called_once()
+    assert result == mock_block
+    assert result.session_id == 1
+
+
+def test_create_block_invalid_session(block_service, mock_services_dao):
+    session_service = mock_services_dao["block_session"]
+    session_service.get_session.return_value = None
+
+    with pytest.raises(ValueError, match="Session not found"):
+        block_service.create_block(
+            block_type=BlockType.emom,
+            position=1,
+            session_id=99,
+        )
+
+
+def test_update_block(block_service, mock_services_dao):
+    mock_dao = mock_services_dao["block"]
+    mock_block = MagicMock()
+
+    mock_dao.get_by_id.return_value = mock_block
+    mock_dao.update.return_value = mock_block
+
+    result = block_service.update_block(
+        1,
+        block_type=BlockType.for_time,
+        duration=10,
+        notes="Updated notes",
+    )
+
+    mock_dao.update.assert_called_once_with(mock_block)
+    assert mock_block.block_type == BlockType.for_time
+    assert mock_block.duration == 10
+    assert mock_block.notes == "Updated notes"
+    assert result == mock_block
+
+
+def test_update_block_not_found(block_service, mock_services_dao):
+    mock_dao = mock_services_dao["block"]
+    mock_dao.get_by_id.return_value = None
+
+    with pytest.raises(ValueError, match="Block not found"):
+        block_service.update_block(99, notes="Nope")
+
+
+def test_get_block(block_service, mock_services_dao):
+    mock_dao = mock_services_dao["block"]
+    mock_block = MagicMock()
+    mock_dao.get_by_id.return_value = mock_block
+
+    result = block_service.get_block(1)
+
+    mock_dao.get_by_id.assert_called_once_with(1)
+    assert result == mock_block
+
+
+def test_list_blocks_by_session(block_service, mock_services_dao):
+    mock_dao = mock_services_dao["block"]
+    mock_list = [MagicMock(), MagicMock()]
+    mock_dao.list_by_session.return_value = mock_list
+
+    result = block_service.list_blocks_by_session(session_id=1)
+
+    mock_dao.list_by_session.assert_called_once_with(1)
+    assert result == mock_list
+
+
+def test_delete_block_success(block_service, mock_services_dao):
+    mock_dao = mock_services_dao["block"]
+    mock_block = MagicMock()
+    mock_dao.get_by_id.return_value = mock_block
+
+    block_service.delete_block(1)
+
+    mock_dao.get_by_id.assert_called_once_with(1)
+    mock_dao.delete.assert_called_once_with(mock_block)
+
+
+def test_delete_block_not_found(block_service, mock_services_dao):
+    mock_dao = mock_services_dao["block"]
+    mock_dao.get_by_id.return_value = None
+
+    with pytest.raises(ValueError, match="Block not found"):
+        block_service.delete_block(99)


### PR DESCRIPTION
### 📌 Summary

This PR introduces full **Block management** across the application, aligned with the existing architecture for `Session` and `Location`.

Blocks can now be created, retrieved, updated, listed, and deleted, always linked to a session.

---

### 🧩 What’s included

- **API**
  - Block routes (CRUD)
  - Block schemas (`Create`, `Read`, `Update`)
- **Data layer**
  - `BlockDAO` with session-scoped queries
- **Service layer**
  - `BlockService` with validation and error handling
- **Tests**
  - DAO tests
  - Service tests
  - API route tests

---

### 🧠 Design choices

- Blocks are **always attached to a session**
- Business validation handled in the **service layer**
- DAO layer remains **thin and SQL-only**
- Consistent structure with `Session` and `Location`

---


