### PR TITLE
🆕🐛🧪 Auto-assign positions and fix DAO/service tests

### DIFF
--- a/src/api/schemas/block.py
+++ b/src/api/schemas/block.py
@@ -4,7 +4,7 @@ from src.data.models import BlockType
 
 class BlockCreate(BaseModel):
     block_type: BlockType = Field(..., description="Type of the block")
-    position: int = Field(..., description="Position of the block within the session")
+    position: int| None = Field(None, description="Position of the block within the session")
     session_id: int = Field(..., description="ID of the session this block belongs to")
     duration: float | None = Field(
         None,

--- a/src/data/dao/block_dao.py
+++ b/src/data/dao/block_dao.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import Session as DBSession
-from sqlalchemy import select
+from sqlalchemy import select, func
 
 from src.data.models import Block
 
@@ -18,7 +18,11 @@ class BlockDAO:
         return self.db.get(Block, block_id)
 
     def list_by_session(self, session_id: int) -> list[Block]:
-        stmt = select(Block).where(Block.session_id == session_id)
+        stmt = (
+                select(Block)
+                .where(Block.session_id == session_id)
+                .order_by(Block.position)
+            )
         return list(self.db.scalars(stmt))
 
     def update(self, block: Block) -> Block:
@@ -29,3 +33,12 @@ class BlockDAO:
     def delete(self, block: Block) -> None:
         self.db.delete(block)
         self.db.commit()
+    
+    def count_by_session(self, session_id: int) -> int:
+        return self.db.scalars(
+            select(func.count())
+            .select_from(Block)
+            .where(Block.session_id == session_id)
+        ).one()
+    
+

--- a/src/data/dao/exercise_dao.py
+++ b/src/data/dao/exercise_dao.py
@@ -1,5 +1,5 @@
 from sqlalchemy.orm import Session as DBSession
-from sqlalchemy import select
+from sqlalchemy import select, func
 
 from src.data.models import Exercise, Block
 
@@ -46,5 +46,24 @@ class ExerciseDAO:
     def validate_block_session(self, block_id: int, session_id: int) -> bool:
         block = self.db.get(Block, block_id)
         return block is not None and block.session_id == session_id
+    
+    def count_free_by_session(self, session_id: int) -> int:
+        return self.db.scalars(
+            select(func.count())
+            .select_from(Exercise)
+            .where(
+                Exercise.session_id == session_id,
+                Exercise.block_id.is_(None),
+            )
+        ).one()
+
+
+    def count_by_block(self, block_id: int) -> int:
+        return self.db.scalars(
+            select(func.count())
+            .select_from(Exercise)
+            .where(Exercise.block_id == block_id)
+        ).one()
+
 
 

--- a/tests/data/dao/test_block_dao.py
+++ b/tests/data/dao/test_block_dao.py
@@ -60,3 +60,13 @@ def test_delete(block_dao, mock_dbs):
 
     mock_db.delete.assert_called_once_with(block)
     mock_db.commit.assert_called_once()
+
+def test_count_by_session(block_dao, mock_dbs):
+    mock_db = mock_dbs["block"]
+
+    mock_scalars = MagicMock()
+    mock_scalars.one.return_value = 2
+    mock_db.scalars.return_value = mock_scalars
+
+    result = block_dao.count_by_session(session_id=1)
+    assert result == 2

--- a/tests/data/dao/test_exercise_dao.py
+++ b/tests/data/dao/test_exercise_dao.py
@@ -76,3 +76,27 @@ def test_validate_block_session_false(exercise_dao, mock_dbs):
     result = exercise_dao.validate_block_session(2, 1)
     mock_db.get.assert_called_once_with(Block, 2)
     assert result is False
+
+def test_count_free_by_session(exercise_dao, mock_dbs):
+    mock_db = mock_dbs["exercise"]
+
+    mock_scalars = MagicMock()
+    mock_scalars.one.return_value = 3
+    mock_db.scalars.return_value = mock_scalars
+
+    result = exercise_dao.count_free_by_session(1)
+    assert result == 3
+
+
+def test_count_by_block(exercise_dao, mock_dbs):
+    mock_db = mock_dbs["exercise"]
+
+    mock_scalars = MagicMock()
+    mock_scalars.one.return_value = 4
+    mock_db.scalars.return_value = mock_scalars
+
+    result = exercise_dao.count_by_block(2)
+    assert result == 4
+
+
+

--- a/tests/services/test_block_service.py
+++ b/tests/services/test_block_service.py
@@ -14,13 +14,18 @@ def test_create_block_with_position(block_service, mock_services_dao):
 
     session_service.get_session.return_value = MagicMock(id=1)
 
-    # Existing items
     existing_block = MagicMock(id=1, position=0)
     free_exercise = MagicMock(id=2, position=1, block_id=None)
 
     block_dao.list_by_session.return_value = [existing_block]
     exercise_dao.list_by_session.return_value = [free_exercise]
 
+    # ⬇️ AJOUTS
+    block_dao.count_by_session.return_value = 1
+    exercise_dao.count_free_by_session.return_value = 1
+
+    block_dao.update.side_effect = lambda b: b
+    exercise_dao.update.side_effect = lambda e: e
     block_dao.create.side_effect = lambda b: b
 
     result = block_service.create_block(
@@ -29,7 +34,6 @@ def test_create_block_with_position(block_service, mock_services_dao):
         position=1,
     )
 
-    # Existing items shifted
     assert free_exercise.position == 2
     exercise_dao.update.assert_called_once_with(free_exercise)
 
@@ -57,32 +61,32 @@ def test_update_block_position_with_shifts(block_service, mock_services_dao):
     block_dao = mock_services_dao["block"]
     exercise_dao = mock_services_dao["block_exercise"]
 
-    # Block to update
     block = MagicMock(id=1, session_id=1, position=0)
     block_dao.get_by_id.return_value = block
     block_dao.update.side_effect = lambda b: b
 
-    # Other items in the session
     other_block = MagicMock(id=2, position=1)
     free_exercise = MagicMock(id=3, position=2, block_id=None)
 
     block_dao.list_by_session.return_value = [block, other_block]
     exercise_dao.list_by_session.return_value = [free_exercise]
 
-    # Act
+    # ⬇️ AJOUTS
+    block_dao.count_by_session.return_value = 2
+    exercise_dao.count_free_by_session.return_value = 1
+
+    exercise_dao.update.side_effect = lambda e: e
+
     result = block_service.update_block(
         block_id=1,
         position=1,
     )
 
-    # Assert final positions
     assert block.position == 1
     assert other_block.position == 0
     assert free_exercise.position == 2
 
     assert result == block
-
-
 
 def test_update_block_not_found(block_service, mock_services_dao):
     block_dao = mock_services_dao["block"]


### PR DESCRIPTION
## Summary
This PR implements automatic position assignment for **blocks** and **exercises** when creating new items in a session.  
It also updates service and dao tests to match the new logic.

---

## 🛠 Changes

### Services
- **ExerciseService**:
  - Auto-assign `position_in_block` for exercises inside a block if not provided.
  - Auto-assign `position` for free exercises if not provided (end of session).
  - Updated position shifting logic for creation, update, and deletion.
  
- **BlockService**:
  - Auto-assign `position` for blocks if not provided (end of session).
  - Fixed position shifting when moving blocks forward/backward.
  
### DAO
- **ExerciseDAO** & **BlockDAO**:
  - Corrected count methods to match actual SQLAlchemy calls (`scalars().one()`).
  
### Schemas
- `BlockCreate` schema: `position` is now optional to support auto-assign.
